### PR TITLE
Handle Windows based file paths

### DIFF
--- a/src/vitePlugin.ts
+++ b/src/vitePlugin.ts
@@ -57,6 +57,7 @@ async function compileElm(
 ): Promise<string> {
   // Example
   // [filePath]: "/Users/Henrikh/Desktop/elmstronaut/examples/minimal/src/elm/src/Greeting/Hello.elm"
+  filePath = path.normalize(filePath);
 
   const cwd = process.cwd();
   // [cwd]: "/Users/Henrikh/Desktop/elmstronaut/examples/minimal"
@@ -80,11 +81,12 @@ async function compileElm(
   const elmDir = path.join(cwd, "src", "elm");
   // [elmDir]: "/Users/Henrikh/Desktop/elmstronaut/examples/minimal/src/elm"
 
-  const elmFileRelativePath = filePath.replace(`${elmDir}/`, "");
+  const elmFileRelativePath = filePath.replace(`${elmDir}/`, "").replace(`${elmDir}\\`, "");
   // [elmFileRelativePath]: "Greeting/Hello.elm"
 
   const elmModuleName = elmFileRelativePath
     .replace("/", ".")
+    .replace("\\", ".")
     .replace(".elm", "");
   // [elmModulePath]: "Greeting.Hello"
 

--- a/src/vitePlugin.ts
+++ b/src/vitePlugin.ts
@@ -81,12 +81,11 @@ async function compileElm(
   const elmDir = path.join(cwd, "src", "elm");
   // [elmDir]: "/Users/Henrikh/Desktop/elmstronaut/examples/minimal/src/elm"
 
-  const elmFileRelativePath = filePath.replace(`${elmDir}/`, "").replace(`${elmDir}\\`, "");
+  const elmFileRelativePath = filePath.replace(`${elmDir}${path.sep}`, "");
   // [elmFileRelativePath]: "Greeting/Hello.elm"
 
   const elmModuleName = elmFileRelativePath
-    .replace("/", ".")
-    .replace("\\", ".")
+    .replace(path.sep, ".")
     .replace(".elm", "");
   // [elmModulePath]: "Greeting.Hello"
 


### PR DESCRIPTION
As the comment in #3 mentions, vitePlugin.ts is currently explicitly handling Unix-like paths. This adds the ability for it to parse elm files with Windows paths. 