### PR TITLE
Add config options for elm compilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,7 @@
   "name": "elmstronaut",
   "version": "0.1.2",
   "description": "Render Elm modules as Astro components",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "type": "module",
   "exports": {
     ".": {
@@ -58,11 +56,7 @@
     "type": "git",
     "url": "git+https://github.com/feedbackone/elmstronaut.git"
   },
-  "keywords": [
-    "astro",
-    "astro-integration",
-    "elm"
-  ],
+  "keywords": ["astro", "astro-integration", "elm"],
   "contributors": [
     {
       "name": "Henrikh Kantuni",

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,9 @@ import vitePlugin from "./vitePlugin.js";
  * });
  * ```
  */
-export default function elmstronaut(): AstroIntegration {
+export default function elmstronaut(
+  elmstronautOptions: ElmstronautOptions = {},
+): AstroIntegration {
   return {
     name: "elmstronaut",
     hooks: {
@@ -35,6 +37,11 @@ export default function elmstronaut(): AstroIntegration {
         injectScript,
         updateConfig,
       }) => {
+        const optionsWithDefaults = setOptionDefaults(
+          command,
+          elmstronautOptions,
+        );
+
         // Inject the bootstrap script.
         // We need this to properly handle `window.onElmInit` callback definition.
         injectScript(
@@ -64,7 +71,7 @@ export default function elmstronaut(): AstroIntegration {
               ],
             },
             server: getViteServerConfig(),
-            plugins: [vitePlugin(command === "dev")],
+            plugins: [vitePlugin(optionsWithDefaults)],
           },
         });
       },
@@ -126,4 +133,17 @@ function watchBootstrapScript(server: ViteDevServer): void {
       server.restart();
     }
   });
+}
+
+function setOptionDefaults(
+  command: "dev" | "build" | "preview" | "sync",
+  elmstronautOptions: ElmstronautOptions,
+): ElmstronautOptions {
+  elmstronautOptions.optimize ??=
+    command !== "dev" && !elmstronautOptions.debug;
+
+  elmstronautOptions.debug ??=
+    command === "dev" && !elmstronautOptions.optimize;
+
+  return elmstronautOptions;
 }

--- a/src/static/elmstronaut.d.ts
+++ b/src/static/elmstronaut.d.ts
@@ -18,6 +18,13 @@ interface ElmApp {
 
 type ElmPort = Incoming | Outgoing;
 
+type ElmstronautOptions = {
+  pathToElm?: string;
+  pathToElmJson?: string;
+  debug?: boolean;
+  optimize?: boolean;
+};
+
 type Incoming = {
   send(...args): void;
 

--- a/src/vitePlugin.ts
+++ b/src/vitePlugin.ts
@@ -14,7 +14,9 @@ import { hashFromPath } from "./utils.js";
  *
  * @param isAstroDevMode - true if Astro is running in development mode
  */
-export default function vitePlugin(isAstroDevMode: boolean): PluginOption {
+export default function vitePlugin(
+  elmstronautOptions: ElmstronautOptions,
+): PluginOption {
   return {
     name: "vite-plugin-elmstronaut",
     async transform(code, id, options) {
@@ -41,7 +43,7 @@ export default function vitePlugin(isAstroDevMode: boolean): PluginOption {
       }
 
       try {
-        const js = await compileElm(id, isAstroDevMode);
+        const js = await compileElm(id, elmstronautOptions);
         return js;
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : "";
@@ -53,7 +55,7 @@ export default function vitePlugin(isAstroDevMode: boolean): PluginOption {
 
 async function compileElm(
   filePath: string,
-  isAstroDevMode: boolean,
+  elmstronautOptions: ElmstronautOptions,
 ): Promise<string> {
   // Example
   // [filePath]: "/Users/Henrikh/Desktop/elmstronaut/examples/minimal/src/elm/src/Greeting/Hello.elm"
@@ -64,7 +66,8 @@ async function compileElm(
   const cwd = process.cwd();
   // [cwd]: "/Users/Henrikh/Desktop/elmstronaut/examples/minimal"
 
-  const elmJsonPath = path.join(cwd, "elm.json");
+  const elmJsonPath =
+    elmstronautOptions.pathToElmJson ?? path.join(cwd, "elm.json");
   // [elmJsonPath]: "/Users/Henrikh/Desktop/elmstronaut/examples/minimal/elm.json"
 
   // Show a helpful error message if `elm.json` is missing
@@ -72,7 +75,9 @@ async function compileElm(
     throw new Error(missingElmJson(elmJsonPath));
   }
 
-  const elmExecutable = path.join(cwd, "node_modules", "elm", "bin", "elm");
+  const elmExecutable =
+    elmstronautOptions.pathToElm ??
+    path.join(cwd, "node_modules", "elm", "bin", "elm");
   // [elmExecutable]: "/Users/Henrikh/Desktop/elmstronaut/examples/minimal/node_modules/elm/bin/elm"
 
   // Show a helpful error message if `elm` executable is missing
@@ -118,7 +123,8 @@ async function compileElm(
         elmFileRelativePath,
         "--output",
         outputFilePath,
-        isAstroDevMode ? "" : "--optimize",
+        elmstronautOptions.optimize ? "--optimize" : "",
+        elmstronautOptions.debug ? "--debug" : "",
       ].filter((s) => s),
       {
         // Execute `elm make` from the same folder where `elm.json` is located.


### PR DESCRIPTION
This commit resolves both #7 and #8 

Added a config options type that can be expanded further with more options later down the line. For now I added what was needed to resolve both issues above as well as a debug options and a pathToElm option for where your elm executable is located option so that can be configured similarly to the node-elm-compiler. 

I remembered to run biome format this time so hopefully we won't have any issues there, but I did notice that biome formatted the package.json that I didn't even touch so hopefully there are no issues there. 

If you want any adjustments or have other config options you'd like added just let me know! Thanks!